### PR TITLE
German translations for Oakpal checks

### DIFF
--- a/core/src/main/resources/net/adamcin/oakpal/core/DefaultErrorListener_de.properties
+++ b/core/src/main/resources/net/adamcin/oakpal/core/DefaultErrorListener_de.properties
@@ -1,0 +1,26 @@
+#
+# Copyright 2020 Mark Adamcin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+NodeType\ registration\ error\ ({0})\:\ {1}\ "{2}"=NodeType Registrierfehler ({0}): {1} "{2}"
+JCR\ namespace\ registration\ error\ ({0}\={1})\:\ {2}\ "{3}"=JCR Namensraum Registrierfehler ({0}={1}): {2} "{3}"
+JCR\ privilege\ registration\ error\ ({0})\:\ {1}\ "{2}"=JCR Privileg Registrierfehler ({0}): {1} "{2}"
+Forced\ root\ creation\ error\ ({0})\:\ {1}\ "{2}"=Forced root Erstellungsfehler ({0}): {1} "{2}"
+Listener\ error\ ({0})\:\ {1}\ "{2}"=Listener Fehler ({0}): {1} "{2}"
+Package\ error\:\ {0}\ "{1}"=Paketfehler: {0} "{1}"
+{0}\ -\ Importer\ error\:\ {1}\ "{2}"={0} - Importer Fehler: {1} "{2}"
+{0}\ -\ Listener\ error\:\ {1}\ "{2}"={0} - Listener Fehler: {1} "{2}"
+InstallHook\ error\:\ {0}\ "{1}"=InstallHook Fehler: {0} "{1}"
+Policy\ prohibits\ the\ use\ of\ InstallHooks\ in\ packages=Policy verbietet die Nutzung von InstallHooks in Paketen

--- a/core/src/main/resources/net/adamcin/oakpal/core/checks/AcHandling_de.properties
+++ b/core/src/main/resources/net/adamcin/oakpal/core/checks/AcHandling_de.properties
@@ -14,6 +14,5 @@
 # limitations under the License.
 #
 
-imported\ path\ {0}\ matches\ deny\ pattern\ {1}=importierter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
-deleted\ path\ {0}.\ All\ deletions\ are\ denied.=gel\u00f6schter Pfad {0}. Alle L\u00f6chungen wurden verweigert.
-deleted\ path\ {0}\ matches\ deny\ rule\ {1}=gel\u00f6schter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
+acHandling\ mode\ {0}\ is\ forbidden.\ acHandling\ values\ in\ allowedModes\ are\ {1}=acHandling Modus {0} ist unzul\u00e4ssig. acHandling Werte in allowedModes sind {1}
+acHandling\ mode\ {0}\ is\ forbidden.\ allowed\ acHandling\ values\ in\ levelSet\:{1}\ are\ {2}=acHandling Modus {0} ist unzul\u00e4ssig. Erlaubte acHandling Werte im levelSet:{1} sind {2}

--- a/core/src/main/resources/net/adamcin/oakpal/core/checks/CompositeStoreAlignment_de.properties
+++ b/core/src/main/resources/net/adamcin/oakpal/core/checks/CompositeStoreAlignment_de.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-imported\ path\ {0}\ matches\ deny\ pattern\ {1}=importierter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
-deleted\ path\ {0}.\ All\ deletions\ are\ denied.=gel\u00f6schter Pfad {0}. Alle L\u00f6chungen wurden verweigert.
-deleted\ path\ {0}\ matches\ deny\ rule\ {1}=gel\u00f6schter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
+package\ content\ not\ aligned\ to\ a\ single\ composite\ store\ mount\ ({0})=Paketinhalt ist nicht auf einen einzigen composite Store Mount ausgerichtet ({0})
+recursive\ package\ installation\ not\ aligned\ to\ a\ single\ composite\ store\ mount\ ({0})=rekursive Paketinstallation ist nicht auf einen einzigen composite Store Mount ausgerichtet ({0})
+and=und

--- a/core/src/main/resources/net/adamcin/oakpal/core/checks/ExpectAces_de.properties
+++ b/core/src/main/resources/net/adamcin/oakpal/core/checks/ExpectAces_de.properties
@@ -14,6 +14,5 @@
 # limitations under the License.
 #
 
-imported\ path\ {0}\ matches\ deny\ pattern\ {1}=importierter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
-deleted\ path\ {0}.\ All\ deletions\ are\ denied.=gel\u00f6schter Pfad {0}. Alle L\u00f6chungen wurden verweigert.
-deleted\ path\ {0}\ matches\ deny\ rule\ {1}=gel\u00f6schter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
+expected\:\ {0}=erwartete: {0}
+unexpected\:\ {0}=unerwartet: {0}

--- a/core/src/main/resources/net/adamcin/oakpal/core/checks/ExpectPaths_de.properties
+++ b/core/src/main/resources/net/adamcin/oakpal/core/checks/ExpectPaths_de.properties
@@ -14,6 +14,5 @@
 # limitations under the License.
 #
 
-imported\ path\ {0}\ matches\ deny\ pattern\ {1}=importierter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
-deleted\ path\ {0}.\ All\ deletions\ are\ denied.=gel\u00f6schter Pfad {0}. Alle L\u00f6chungen wurden verweigert.
-deleted\ path\ {0}\ matches\ deny\ rule\ {1}=gel\u00f6schter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
+expected\ path\ missing\:\ {0}=erwarteter Pfad fehlt: {0}
+unexpected\ path\ present\:\ {0}=unerwarteter Pfad enthalten: {0}

--- a/core/src/main/resources/net/adamcin/oakpal/core/checks/FilterSets_de.properties
+++ b/core/src/main/resources/net/adamcin/oakpal/core/checks/FilterSets_de.properties
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-imported\ path\ {0}\ matches\ deny\ pattern\ {1}=importierter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
-deleted\ path\ {0}.\ All\ deletions\ are\ denied.=gel\u00f6schter Pfad {0}. Alle L\u00f6chungen wurden verweigert.
-deleted\ path\ {0}\ matches\ deny\ rule\ {1}=gel\u00f6schter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
+empty\ workspace\ filter\ is\ not\ allowed=leere Workspace Filter sind nicht erlaubt
+non-default\ import\ mode\ {0}\ defined\ for\ filterSet\ with\ root\ {1}= non-default Importmodus {0} definiert f\u00fcr filterSet mit Wurzel {1}
+root\ filter\ sets\ are\ not\ allowed=Root-Filtersets sind nicht erlaubt

--- a/core/src/main/resources/net/adamcin/oakpal/core/checks/JcrProperties_de.properties
+++ b/core/src/main/resources/net/adamcin/oakpal/core/checks/JcrProperties_de.properties
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
-imported\ path\ {0}\ matches\ deny\ pattern\ {1}=importierter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
-deleted\ path\ {0}.\ All\ deletions\ are\ denied.=gel\u00f6schter Pfad {0}. Alle L\u00f6chungen wurden verweigert.
-deleted\ path\ {0}\ matches\ deny\ rule\ {1}=gel\u00f6schter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
+{0}\ (t\:\ {1},\ m\:\ {2})\:\ denied\ node\ type\ {3}={0} (t: {1}, m: {2}): abgelehnter Knotentyp {3}
+property\ absent=Property fehlt
+property\ present=Property enthalten
+property\ is\ multivalued=Property ist mehrwertig
+required\ type\ mismatch\:\ {0}\ !\=\ {1}=erforderlicher Typ passt nicht: {0} != {1}
+value\ {0}\ denied\ by\ pattern\ {1}=Wert {0} wurde verweigert durch Pattern {1}

--- a/core/src/main/resources/net/adamcin/oakpal/core/checks/Overlaps_de.properties
+++ b/core/src/main/resources/net/adamcin/oakpal/core/checks/Overlaps_de.properties
@@ -14,6 +14,4 @@
 # limitations under the License.
 #
 
-imported\ path\ {0}\ matches\ deny\ pattern\ {1}=importierter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
-deleted\ path\ {0}.\ All\ deletions\ are\ denied.=gel\u00f6schter Pfad {0}. Alle L\u00f6chungen wurden verweigert.
-deleted\ path\ {0}\ matches\ deny\ rule\ {1}=gel\u00f6schter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
+affected\ path\ {0}\ overlaps\ {1}=betroffener Pfad {0} \u00fcberlappt mit {1}

--- a/core/src/main/resources/net/adamcin/oakpal/core/checks/Paths_de.properties
+++ b/core/src/main/resources/net/adamcin/oakpal/core/checks/Paths_de.properties
@@ -15,5 +15,5 @@
 #
 
 imported\ path\ {0}\ matches\ deny\ pattern\ {1}=importierter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
-deleted\ path\ {0}.\ All\ deletions\ are\ denied.=gel\u00f6schter Pfad {0}. Alle L\u00f6chungen wurden verweigert.
+deleted\ path\ {0}.\ All\ deletions\ are\ denied.=gel\u00f6schter Pfad {0}. Alle L\u00f6schungen wurden verweigert.
 deleted\ path\ {0}\ matches\ deny\ rule\ {1}=gel\u00f6schter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}

--- a/core/src/main/resources/net/adamcin/oakpal/core/checks/Subpackages_de.properties
+++ b/core/src/main/resources/net/adamcin/oakpal/core/checks/Subpackages_de.properties
@@ -14,6 +14,5 @@
 # limitations under the License.
 #
 
-imported\ path\ {0}\ matches\ deny\ pattern\ {1}=importierter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
-deleted\ path\ {0}.\ All\ deletions\ are\ denied.=gel\u00f6schter Pfad {0}. Alle L\u00f6chungen wurden verweigert.
-deleted\ path\ {0}\ matches\ deny\ rule\ {1}=gel\u00f6schter Pfad {0} stimmt mit dem deny Pattern \u00fcberein {1}
+subpackage\ {0}\ included\ by\ {1}.\ no\ subpackages\ are\ allowed.=Subpackage {0} ist beinhaltet in {1}. Subpackages sind nicht erlaubt.
+subpackage\ {0}\ included\ by\ {1}\ matches\ deny\ pattern\ {2}=Subpackage {0} beinhaltet in {1} stimmt mit dem deny Pattern \u00fcberein {2}


### PR DESCRIPTION
Relates to issue #24


- I followed your style and usually started the messages with lowercase - except when the first word is a noun (in German nouns are capitalized)
- In many cases, I didn't translate technical English words. That's not uncommon in the German language, especially in tech
