### PR TITLE
fix Dockerfile for version 2.0.0 introduction of oakpal-api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM maven:3.6.1-jdk-8 AS build
+FROM maven:3.6.3-jdk-8 AS build
 ADD . /app
 WORKDIR /app
-RUN mvn clean install -pl testing,core,cli
+RUN mvn -B clean install -am -pl cli
 
 FROM adoptopenjdk/openjdk14-openj9:alpine-slim
 RUN mkdir -p /app/oakpal-cli


### PR DESCRIPTION
Not an issue for the 2.0.0 release build itself, because the oakpal-api module artifact was resolved from maven central. 