### PR TITLE
Some updates to the add-jcrinstall-simulator branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## [Unreleased]
 
+## [2.1.0] - 2020-05-28
+
 ### Added
 
 - Added repoinit support for init stages adapted from plans and checklists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Added
 
 - Added repoinit support for init stages adapted from plans and checklists.
+- OakMachine now skips subpackage extraction based on SubPackageHandling.
 
 ## [2.0.0] - 2020-04-27
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>v2.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>HEAD</tag>
+        <tag>v2.1.0</tag>
     </scm>
 
     <build>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>v2.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>HEAD</tag>
+        <tag>v2.1.0</tag>
     </scm>
 
     <build>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>v2.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>HEAD</tag>
+        <tag>v2.1.0</tag>
     </scm>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -87,7 +87,9 @@
                                     net.adamcin.oakpal.core.checks,\
                                     net.adamcin.oakpal.core.opear
                                 Private-Package: net.adamcin.oakpal.core.jcrfacade.*
-                                Import-Package: !aQute.*,*
+                                Import-Package: !aQute.*,\
+                                    !org.apache.sling.jcr.repoinit.*,\
+                                    *
                             ]]></bnd>
                         </configuration>
                     </execution>
@@ -128,6 +130,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>biz.aQute.bnd:bndlib</include>
+                                    <include>org.apache.sling:org.apache.sling.jcr.repoinit</include>
                                 </includes>
                             </artifactSet>
                             <filters>
@@ -144,11 +147,21 @@
                                         <include>aQute/service/reporter/**</include>
                                     </includes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.apache.sling:org.apache.sling.jcr.repoinit</artifact>
+                                    <includes>
+                                        <include>org/apache/sling/jcr/repoinit/**</include>
+                                    </includes>
+                                </filter>
                             </filters>
                             <relocations>
                                 <relocation>
                                     <pattern>aQute</pattern>
                                     <shadedPattern>net.adamcin.oakpal.shaded.aQute</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.sling.jcr.repoinit</pattern>
+                                    <shadedPattern>net.adamcin.oakpal.shaded.repoinit</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>
@@ -198,6 +211,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.repoinit</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/core/src/main/java/net/adamcin/oakpal/core/ErrorListener.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/ErrorListener.java
@@ -20,7 +20,7 @@ import net.adamcin.oakpal.api.ProgressCheck;
 import net.adamcin.oakpal.api.ScanListener;
 import net.adamcin.oakpal.api.ViolationReporter;
 import net.adamcin.oakpal.core.installable.RepoInitInstallable;
-import net.adamcin.oakpal.core.installable.SubpackageInstallable;
+import net.adamcin.oakpal.core.installable.EmbeddedPackageInstallable;
 import org.apache.jackrabbit.vault.packaging.PackageId;
 import org.osgi.annotation.versioning.ConsumerType;
 
@@ -179,7 +179,7 @@ public interface ErrorListener extends ScanListener, ViolationReporter {
      */
     default void onInstallableSubpackageError(final Throwable error,
                                               final PackageId lastPackage,
-                                              final SubpackageInstallable installable) {
+                                              final EmbeddedPackageInstallable installable) {
 
     }
 }

--- a/core/src/main/java/net/adamcin/oakpal/core/OakMachine.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/OakMachine.java
@@ -852,7 +852,6 @@ public final class OakMachine {
 
     final void internalProcessSubpackage(final @NotNull Session admin,
                                          final @NotNull JcrPackageManager manager,
-                                         final @NotNull PackageId packageId,
                                          final @NotNull PackageId parentId,
                                          final boolean preInstall,
                                          final @NotNull Fun.ThrowingSupplier<JcrPackage> jcrPackageSupplier,
@@ -860,6 +859,7 @@ public final class OakMachine {
                                          final @NotNull Consumer<Exception> onError) throws RepositoryException {
         try (JcrPackage jcrPackage = jcrPackageSupplier.tryGet()) {
             if (jcrPackage != null) {
+                PackageId packageId = jcrPackage.getPackage().getId();
                 propagateCheckPackageEvent(preInstall, packageId, progressCheck ->
                         progressCheck.identifySubpackage(packageId, parentId, jcrPathFn.apply(jcrPackage)));
 
@@ -880,7 +880,7 @@ public final class OakMachine {
                                  final @NotNull PackageId packageId,
                                  final @NotNull PackageId parentId,
                                  final boolean preInstall) throws RepositoryException {
-        internalProcessSubpackage(admin, manager, packageId, parentId, preInstall,
+        internalProcessSubpackage(admin, manager, parentId, preInstall,
                 () -> manager.open(packageId),
                 jcrPackage -> Optional.ofNullable(jcrPackage.getNode())
                         .flatMap(compose1(result1(Node::getPath), Result::toOptional))
@@ -898,7 +898,7 @@ public final class OakMachine {
                 error -> getErrorListener().onInstallableSubpackageError(error, lastPackage, installable);
         Optional<Fun.ThrowingSupplier<JcrPackage>> supplierOptional = installWatcher.openSubpackageInstallable(installable, admin, manager);
         if (supplierOptional.isPresent()) {
-            internalProcessSubpackage(admin, manager, installable.getSubpackageId(), installable.getParentId(),
+            internalProcessSubpackage(admin, manager, installable.getParentId(),
                     preInstall, supplierOptional.get(), constantly1(installable::getJcrPath), onError);
         }
     }

--- a/core/src/main/java/net/adamcin/oakpal/core/installable/EmbeddedPackageInstallable.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/installable/EmbeddedPackageInstallable.java
@@ -16,20 +16,28 @@
 
 package net.adamcin.oakpal.core.installable;
 
+import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.PackageId;
-import org.junit.Test;
+import org.jetbrains.annotations.NotNull;
 
-import static org.junit.Assert.*;
+public final class EmbeddedPackageInstallable implements PathInstallable<JcrPackage> {
+    private final PackageId parentId;
+    private final String jcrPath;
 
-public class SubpackageInstallableTest {
-    @Test
-    public void testConstructorAndGetters() {
-        final PackageId expectParentId = PackageId.fromString("test:test:1");
-        final String expectJcrPath = "/some/path";
-        final SubpackageInstallable installable =
-                new SubpackageInstallable(expectParentId, expectJcrPath);
+    public EmbeddedPackageInstallable(final PackageId parentId, final String jcrPath) {
+        this.parentId = parentId;
+        this.jcrPath = jcrPath;
+    }
 
-        assertSame("expect parentId", expectParentId, installable.getParentId());
-        assertSame("expect jcrPath", expectJcrPath, installable.getJcrPath());
+    @NotNull
+    @Override
+    public PackageId getParentId() {
+        return parentId;
+    }
+
+    @NotNull
+    @Override
+    public String getJcrPath() {
+        return jcrPath;
     }
 }

--- a/core/src/main/java/net/adamcin/oakpal/core/installable/JcrInstallWatcher.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/installable/JcrInstallWatcher.java
@@ -19,53 +19,30 @@ package net.adamcin.oakpal.core.installable;
 import net.adamcin.oakpal.api.Fun;
 import net.adamcin.oakpal.api.ProgressCheck;
 import net.adamcin.oakpal.core.SilenceableViolationReporter;
-import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 import javax.jcr.Session;
-import java.io.Reader;
-import java.util.Optional;
 
 /**
  * Interface defining methods for collecting Sling JCR installable resources.
  */
-@ProviderType
-public interface JcrInstallWatcher extends SilenceableViolationReporter, ProgressCheck {
+@ConsumerType
+public interface JcrInstallWatcher extends SilenceableViolationReporter, ProgressCheck, Iterable<PathInstallable> {
 
     /**
-     * Get the collected installable paths. The consumer of this method is instructed to treat the returned map as an
-     * iterable. Each entry gives the path as a key, and the installable type as the value. The type enum should be used
-     * by the consumer to call the appropriate get method
-     *
-     * @return an iterable map of JCR paths to installable types
-     */
-    @Nullable PathInstallable dequeueInstallable();
-
-    /**
-     * Get installable repoinit scripts from the specified JCR path.
+     * Get installable entities from the specified JCR path.
      *
      * @param session     the admin session
      * @param installable the installable
-     * @return a list of reader suppliers from the provided JCR path
-     */
-    @NotNull Iterable<Fun.ThrowingSupplier<Reader>>
-    openRepoInitInstallable(@NotNull RepoInitInstallable installable,
-                            @NotNull Session session);
-
-    /**
-     * Get installable JCR package from the specified JCR path.
-     *
-     * @param installable    the subpackage installable
-     * @param session        the admin session
      * @param packageManager the JCR package manager
-     * @return an optional subpackage supplier
+     * @return a list of entity suppliers from the provided JCR path
      */
-    @NotNull Optional<Fun.ThrowingSupplier<JcrPackage>>
-    openSubpackageInstallable(@NotNull SubpackageInstallable installable,
-                              @NotNull Session session,
-                              @NotNull JcrPackageManager packageManager);
+    @NotNull <EntityType> Iterable<Fun.ThrowingSupplier<EntityType>>
+    open(@NotNull PathInstallable<EntityType> installable,
+                            @NotNull Session session,
+                            @NotNull JcrPackageManager packageManager);
+
 
 }

--- a/core/src/main/java/net/adamcin/oakpal/core/installable/JcrInstallWatcher.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/installable/JcrInstallWatcher.java
@@ -29,7 +29,7 @@ import javax.jcr.Session;
  * Interface defining methods for collecting Sling JCR installable resources.
  */
 @ConsumerType
-public interface JcrInstallWatcher extends SilenceableViolationReporter, ProgressCheck, Iterable<PathInstallable> {
+public interface JcrInstallWatcher extends SilenceableViolationReporter, ProgressCheck, Iterable<PathInstallable<?>> {
 
     /**
      * Get installable entities from the specified JCR path.

--- a/core/src/main/java/net/adamcin/oakpal/core/installable/NoopInstallWatcher.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/installable/NoopInstallWatcher.java
@@ -54,7 +54,7 @@ public final class NoopInstallWatcher implements JcrInstallWatcher {
 
     @NotNull
     @Override
-    public Iterator<PathInstallable> iterator() {
+    public Iterator<PathInstallable<?>> iterator() {
         return Collections.emptyIterator();
     }
 

--- a/core/src/main/java/net/adamcin/oakpal/core/installable/NoopInstallWatcher.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/installable/NoopInstallWatcher.java
@@ -27,6 +27,7 @@ import javax.jcr.Session;
 import java.io.Reader;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Optional;
 
 /**
@@ -51,24 +52,18 @@ public final class NoopInstallWatcher implements JcrInstallWatcher {
         return NoopInstallWatcher.class.getSimpleName();
     }
 
+    @NotNull
     @Override
-    public @Nullable PathInstallable dequeueInstallable() {
-        return null;
+    public Iterator<PathInstallable> iterator() {
+        return Collections.emptyIterator();
     }
 
     @Override
-    public @NotNull Iterable<Fun.ThrowingSupplier<Reader>>
-    openRepoInitInstallable(@NotNull final RepoInitInstallable installable,
-                            @NotNull final Session session) {
+    public @NotNull <EntityType> Iterable<Fun.ThrowingSupplier<EntityType>>
+    open(@NotNull PathInstallable<EntityType> installable,
+         @NotNull Session session,
+         @NotNull JcrPackageManager packageManager) {
         return Collections.emptyList();
-    }
-
-    @Override
-    public @NotNull Optional<Fun.ThrowingSupplier<JcrPackage>>
-    openSubpackageInstallable(@NotNull final SubpackageInstallable installable,
-                              @NotNull final Session session,
-                              @NotNull final JcrPackageManager packageManager) {
-        return Optional.empty();
     }
 
     @Override

--- a/core/src/main/java/net/adamcin/oakpal/core/installable/PathInstallable.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/installable/PathInstallable.java
@@ -21,10 +21,23 @@ import org.jetbrains.annotations.NotNull;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
- *
+ * Represents an installable entity which was detected during a package scan which should be subject to
+ * a scan.
  */
 @ProviderType
-public interface PathInstallable {
+public interface PathInstallable<EntityType> {
+
+    /**
+     * The id of the containing package.
+     *
+     * @return the package id
+     */
     @NotNull PackageId getParentId();
+
+    /**
+     * The JCR path for the installable entity.
+     *
+     * @return the path of the entity
+     */
     @NotNull String getJcrPath();
 }

--- a/core/src/main/java/net/adamcin/oakpal/core/installable/RepoInitInstallable.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/installable/RepoInitInstallable.java
@@ -19,10 +19,12 @@ package net.adamcin.oakpal.core.installable;
 import org.apache.jackrabbit.vault.packaging.PackageId;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.Reader;
+
 /**
  * Locates a jcr path that should be treated as an installable provider of repoinit scripts.
  */
-public final class RepoInitInstallable implements PathInstallable {
+public final class RepoInitInstallable implements PathInstallable<Reader> {
     private final PackageId parentId;
     private final String jcrPath;
 

--- a/core/src/main/java/net/adamcin/oakpal/core/installable/SubpackageInstallable.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/installable/SubpackageInstallable.java
@@ -22,12 +22,10 @@ import org.jetbrains.annotations.NotNull;
 public final class SubpackageInstallable implements PathInstallable {
     private final PackageId parentId;
     private final String jcrPath;
-    private final PackageId subpackageId;
 
-    public SubpackageInstallable(final PackageId parentId, final String jcrPath, final PackageId subpackageId) {
+    public SubpackageInstallable(final PackageId parentId, final String jcrPath) {
         this.parentId = parentId;
         this.jcrPath = jcrPath;
-        this.subpackageId = subpackageId;
     }
 
     @NotNull
@@ -40,9 +38,5 @@ public final class SubpackageInstallable implements PathInstallable {
     @Override
     public String getJcrPath() {
         return jcrPath;
-    }
-
-    public PackageId getSubpackageId() {
-        return subpackageId;
     }
 }

--- a/core/src/main/java/net/adamcin/oakpal/core/repoinit/DefaultRepoInitFactory.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/repoinit/DefaultRepoInitFactory.java
@@ -18,6 +18,7 @@ package net.adamcin.oakpal.core.repoinit;
 
 import net.adamcin.oakpal.core.OakMachine;
 import org.apache.sling.jcr.repoinit.JcrRepoInitOpsProcessor;
+import org.apache.sling.jcr.repoinit.impl.JcrRepoInitOpsProcessorImpl;
 import org.apache.sling.repoinit.parser.RepoInitParser;
 import org.apache.sling.repoinit.parser.RepoInitParsingException;
 import org.apache.sling.repoinit.parser.operations.Operation;
@@ -38,26 +39,19 @@ public final class DefaultRepoInitFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRepoInitFactory.class);
     private static final String REPO_INIT_PARSER_IMPL_CLASS =
             "org.apache.sling.repoinit.parser.impl.RepoInitParserService";
-    private static final String REPO_INIT_OPS_PROCESSOR_IMPL_CLASS =
-            "org.apache.sling.jcr.repoinit.impl.JcrRepoInitOpsProcessorImpl";
 
     Class<? extends RepoInitParser> parserClazz;
-    Class<? extends JcrRepoInitOpsProcessor> opsProcessorClazz;
 
     static final OakMachine.RepoInitProcessor NOOP_PROCESSOR = (admin, reader) -> {
         throw new RepoInitParsingException("repoinit processor is not available", null);
     };
 
-    DefaultRepoInitFactory(final @Nullable Class<? extends RepoInitParser> parserClazz,
-                           final @Nullable Class<? extends JcrRepoInitOpsProcessor> opsProcessorClazz) {
+    DefaultRepoInitFactory(final @Nullable Class<? extends RepoInitParser> parserClazz) {
         this.parserClazz = parserClazz;
-        this.opsProcessorClazz = opsProcessorClazz;
     }
 
-    public static DefaultRepoInitFactory newFactoryInstance(final @NotNull ClassLoader parserCl,
-                                                            final @NotNull ClassLoader processorCl) {
-        return new DefaultRepoInitFactory(loadClazz(parserCl, RepoInitParser.class, REPO_INIT_PARSER_IMPL_CLASS),
-                loadClazz(processorCl, JcrRepoInitOpsProcessor.class, REPO_INIT_OPS_PROCESSOR_IMPL_CLASS));
+    public static DefaultRepoInitFactory newFactoryInstance(final @NotNull ClassLoader parserCl) {
+        return new DefaultRepoInitFactory(loadClazz(parserCl, RepoInitParser.class, REPO_INIT_PARSER_IMPL_CLASS));
     }
 
     static <T> @Nullable Class<? extends T> loadClazz(final @NotNull ClassLoader classLoader,
@@ -83,22 +77,19 @@ public final class DefaultRepoInitFactory {
     public static OakMachine.RepoInitProcessor newDefaultRepoInitProcessor(
             final @NotNull ClassLoader defaultClassLoader) {
         final DefaultRepoInitFactory factory =
-                DefaultRepoInitFactory.newFactoryInstance(defaultClassLoader, defaultClassLoader);
+                DefaultRepoInitFactory.newFactoryInstance(defaultClassLoader);
         return factory.newInstance();
     }
 
     OakMachine.RepoInitProcessor newInstance() {
         final RepoInitParser repoInitParser = newParser();
-        final JcrRepoInitOpsProcessor opsProcessor = newOpsProcessor();
         return ofNullable(repoInitParser)
-                .flatMap(parser ->
-                        ofNullable(opsProcessor).map(processor ->
-                                bindParserProcessor(parser, processor)))
+                .map(DefaultRepoInitFactory::bindParser)
                 .orElse(NOOP_PROCESSOR);
     }
 
-    public static OakMachine.RepoInitProcessor bindParserProcessor(final @NotNull RepoInitParser parser,
-                                                                   final @NotNull JcrRepoInitOpsProcessor processor) {
+    public static OakMachine.RepoInitProcessor bindParser(final @NotNull RepoInitParser parser) {
+        final JcrRepoInitOpsProcessor processor = newOpsProcessor();
         return (admin, reader) -> {
             final List<Operation> parsed = parser.parse(reader);
             processor.apply(admin, parsed);
@@ -116,15 +107,8 @@ public final class DefaultRepoInitFactory {
         return null;
     }
 
-    JcrRepoInitOpsProcessor newOpsProcessor() {
-        if (opsProcessorClazz != null) {
-            try {
-                return opsProcessorClazz.getConstructor().newInstance();
-            } catch (Exception e) {
-                LOGGER.warn("failed to construct instance of " + opsProcessorClazz.getName(), e);
-            }
-        }
-        return null;
+    static JcrRepoInitOpsProcessor newOpsProcessor() {
+        return new JcrRepoInitOpsProcessorImpl();
     }
 }
 

--- a/core/src/test/java/net/adamcin/oakpal/core/OakMachineTest.java
+++ b/core/src/test/java/net/adamcin/oakpal/core/OakMachineTest.java
@@ -667,7 +667,7 @@ public class OakMachineTest {
         final PackageId root = PackageId.fromString("my_packages:subsubtest");
         final PackageId sub1 = PackageId.fromString("my_packages:subtest");
         final String jcrPath = "/some/path";
-        final SubpackageInstallable installable = new SubpackageInstallable(root, jcrPath, sub1);
+        final SubpackageInstallable installable = new SubpackageInstallable(root, jcrPath);
         final Session session = mock(Session.class);
         final CompletableFuture<Exception> eLatch = new CompletableFuture<>();
         final CompletableFuture<PackageId> idLatch = new CompletableFuture<>();
@@ -700,7 +700,7 @@ public class OakMachineTest {
         final PackageId root = PackageId.fromString("my_packages:subsubtest");
         final PackageId sub1 = PackageId.fromString("my_packages:subtest");
         final String jcrPath = "/some/path";
-        final SubpackageInstallable installable = new SubpackageInstallable(root, jcrPath, sub1);
+        final SubpackageInstallable installable = new SubpackageInstallable(root, jcrPath);
         final Session session = mock(Session.class);
         doThrow(RepositoryException.class).when(session).refresh(anyBoolean());
         final CompletableFuture<Exception> eLatch = new CompletableFuture<>();
@@ -743,7 +743,7 @@ public class OakMachineTest {
             return true;
         }).when(errorListener).onSubpackageException(any(Exception.class), any(PackageId.class));
         builder().withErrorListener(errorListener).build()
-                .internalProcessSubpackage(session, manager, sub1, root, false,
+                .internalProcessSubpackage(session, manager, root, false,
                         () -> manager.open(sub1), constantly1(() -> "/some/path"),
                         error -> errorListener.onSubpackageException(error, sub1));
         assertTrue("error is of type", eLatch.getNow(null) instanceof PackageException);
@@ -771,7 +771,7 @@ public class OakMachineTest {
         }).when(errorListener).onSubpackageException(any(Exception.class), any(PackageId.class));
 
         builder().withErrorListener(errorListener).build()
-                .internalProcessSubpackage(session, manager, sub1, root, false,
+                .internalProcessSubpackage(session, manager, root, false,
                         () -> manager.open(sub1), constantly1(() -> "/some/path"),
                         error -> errorListener.onSubpackageException(error, sub1));
         assertTrue("error is of type", eLatch.getNow(null) instanceof RuntimeException);
@@ -796,7 +796,7 @@ public class OakMachineTest {
         final PackageId root = PackageId.fromString("my_packages:subsubtest");
         final PackageId sub1 = PackageId.fromString("my_packages:subtest");
         final String jcrPath = "/some/path";
-        final SubpackageInstallable installable = new SubpackageInstallable(root, jcrPath, sub1);
+        final SubpackageInstallable installable = new SubpackageInstallable(root, jcrPath);
         final List<SubpackageInstallable> installables = new ArrayList<>();
         installables.add(installable);
         final JcrInstallWatcher installWatcher = mock(JcrInstallWatcher.class);

--- a/core/src/test/java/net/adamcin/oakpal/core/installable/EmbeddedPackageInstallableTest.java
+++ b/core/src/test/java/net/adamcin/oakpal/core/installable/EmbeddedPackageInstallableTest.java
@@ -17,26 +17,19 @@
 package net.adamcin.oakpal.core.installable;
 
 import org.apache.jackrabbit.vault.packaging.PackageId;
-import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
 
-public final class SubpackageInstallable implements PathInstallable {
-    private final PackageId parentId;
-    private final String jcrPath;
+import static org.junit.Assert.*;
 
-    public SubpackageInstallable(final PackageId parentId, final String jcrPath) {
-        this.parentId = parentId;
-        this.jcrPath = jcrPath;
-    }
+public class EmbeddedPackageInstallableTest {
+    @Test
+    public void testConstructorAndGetters() {
+        final PackageId expectParentId = PackageId.fromString("test:test:1");
+        final String expectJcrPath = "/some/path";
+        final EmbeddedPackageInstallable installable =
+                new EmbeddedPackageInstallable(expectParentId, expectJcrPath);
 
-    @NotNull
-    @Override
-    public PackageId getParentId() {
-        return parentId;
-    }
-
-    @NotNull
-    @Override
-    public String getJcrPath() {
-        return jcrPath;
+        assertSame("expect parentId", expectParentId, installable.getParentId());
+        assertSame("expect jcrPath", expectJcrPath, installable.getJcrPath());
     }
 }

--- a/core/src/test/java/net/adamcin/oakpal/core/installable/NoopInstallWatcherTest.java
+++ b/core/src/test/java/net/adamcin/oakpal/core/installable/NoopInstallWatcherTest.java
@@ -57,7 +57,7 @@ public class NoopInstallWatcherTest {
     public void testOpenSubpackageInstallable() {
         assertNotNull("expect non-null iteratable",
                 instance().openSubpackageInstallable(
-                        new SubpackageInstallable(null, null, null),
+                        new SubpackageInstallable(null, null),
                         mock(Session.class),
                         mock(JcrPackageManager.class)));
     }

--- a/core/src/test/java/net/adamcin/oakpal/core/installable/NoopInstallWatcherTest.java
+++ b/core/src/test/java/net/adamcin/oakpal/core/installable/NoopInstallWatcherTest.java
@@ -21,10 +21,12 @@ import org.junit.Test;
 
 import javax.jcr.Session;
 
+import java.util.Iterator;
+
 import static net.adamcin.oakpal.core.installable.NoopInstallWatcher.instance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 
 public class NoopInstallWatcherTest {
@@ -41,23 +43,26 @@ public class NoopInstallWatcherTest {
     }
 
     @Test
-    public void testDequeueInstallable() {
-        assertNull("never dequeue an installable", instance().dequeueInstallable());
+    public void testIteratable() {
+        Iterator<PathInstallable> iterator = instance().iterator();
+        assertNotNull("expect non-null iterator", iterator);
+        assertFalse("iterator is empty", iterator.hasNext());
     }
 
     @Test
     public void testOpenRepoInitInstallable() {
         assertNotNull("expect non-null iteratable",
-                instance().openRepoInitInstallable(
+                instance().open(
                         new RepoInitInstallable(null, null),
-                        mock(Session.class)));
+                        mock(Session.class),
+                        mock(JcrPackageManager.class)));
     }
 
     @Test
     public void testOpenSubpackageInstallable() {
         assertNotNull("expect non-null iteratable",
-                instance().openSubpackageInstallable(
-                        new SubpackageInstallable(null, null),
+                instance().open(
+                        new EmbeddedPackageInstallable(null, null),
                         mock(Session.class),
                         mock(JcrPackageManager.class)));
     }

--- a/core/src/test/java/net/adamcin/oakpal/core/installable/NoopInstallWatcherTest.java
+++ b/core/src/test/java/net/adamcin/oakpal/core/installable/NoopInstallWatcherTest.java
@@ -44,7 +44,7 @@ public class NoopInstallWatcherTest {
 
     @Test
     public void testIteratable() {
-        Iterator<PathInstallable> iterator = instance().iterator();
+        Iterator<PathInstallable<?>> iterator = instance().iterator();
         assertNotNull("expect non-null iterator", iterator);
         assertFalse("iterator is empty", iterator.hasNext());
     }

--- a/core/src/test/java/net/adamcin/oakpal/core/installable/SubpackageInstallableTest.java
+++ b/core/src/test/java/net/adamcin/oakpal/core/installable/SubpackageInstallableTest.java
@@ -26,12 +26,10 @@ public class SubpackageInstallableTest {
     public void testConstructorAndGetters() {
         final PackageId expectParentId = PackageId.fromString("test:test:1");
         final String expectJcrPath = "/some/path";
-        final PackageId expectSubpackageId = PackageId.fromString("test:testtest:1");
         final SubpackageInstallable installable =
-                new SubpackageInstallable(expectParentId, expectJcrPath, expectSubpackageId);
+                new SubpackageInstallable(expectParentId, expectJcrPath);
 
         assertSame("expect parentId", expectParentId, installable.getParentId());
         assertSame("expect jcrPath", expectJcrPath, installable.getJcrPath());
-        assertSame("expect subpackageId", expectSubpackageId, installable.getSubpackageId());
     }
 }

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>v2.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>HEAD</tag>
+        <tag>v2.1.0</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>net.adamcin.oakpal</groupId>
     <artifactId>oakpal</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <inceptionYear>2017</inceptionYear>
@@ -498,22 +498,22 @@
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-testing</artifactId>
-                <version>2.1.1-SNAPSHOT</version>
+                <version>2.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-api</artifactId>
-                <version>2.1.1-SNAPSHOT</version>
+                <version>2.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-core</artifactId>
-                <version>2.1.1-SNAPSHOT</version>
+                <version>2.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-webster</artifactId>
-                <version>2.1.1-SNAPSHOT</version>
+                <version>2.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>net.adamcin.oakpal</groupId>
     <artifactId>oakpal</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <inceptionYear>2017</inceptionYear>
@@ -43,7 +43,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>v2.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>
@@ -498,22 +498,22 @@
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-testing</artifactId>
-                <version>2.1.0</version>
+                <version>2.1.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-api</artifactId>
-                <version>2.1.0</version>
+                <version>2.1.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-core</artifactId>
-                <version>2.1.0</version>
+                <version>2.1.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-webster</artifactId>
-                <version>2.1.0</version>
+                <version>2.1.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>net.adamcin.oakpal</groupId>
     <artifactId>oakpal</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0</version>
     <packaging>pom</packaging>
 
     <inceptionYear>2017</inceptionYear>
@@ -43,7 +43,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>HEAD</tag>
+        <tag>v2.1.0</tag>
     </scm>
 
     <distributionManagement>
@@ -498,22 +498,22 @@
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-testing</artifactId>
-                <version>2.1.0-SNAPSHOT</version>
+                <version>2.1.0</version>
             </dependency>
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-api</artifactId>
-                <version>2.1.0-SNAPSHOT</version>
+                <version>2.1.0</version>
             </dependency>
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-core</artifactId>
-                <version>2.1.0-SNAPSHOT</version>
+                <version>2.1.0</version>
             </dependency>
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-webster</artifactId>
-                <version>2.1.0-SNAPSHOT</version>
+                <version>2.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains</groupId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>v2.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>HEAD</tag>
+        <tag>v2.1.0</tag>
     </scm>
 
     <build>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/webster/pom.xml
+++ b/webster/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>v2.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/webster/pom.xml
+++ b/webster/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.1.0</version>
         <relativePath>..</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <url>https://github.com/adamcin/oakpal</url>
         <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
         <connection>scm:git://github.com/adamcin/oakpal.git</connection>
-        <tag>HEAD</tag>
+        <tag>v2.1.0</tag>
     </scm>
 
     <build>

--- a/webster/pom.xml
+++ b/webster/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>net.adamcin.oakpal</groupId>
         <artifactId>oakpal</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 


### PR DESCRIPTION
@adamcin trying to revive this 😄 

* Merged (with fixing some conflicts) master
* Bumped versions
* Removed the subPackageId field from `SubpackageInstallable` -- after doing some experimentation, this seemed to be unnecessary and added overhead. 