### PR TITLE
minor JCR install fixes

### DIFF
--- a/core/src/main/java/net/adamcin/oakpal/core/checks/SlingJcrInstaller.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/checks/SlingJcrInstaller.java
@@ -67,7 +67,7 @@ public final class SlingJcrInstaller implements ProgressCheckFactory {
     }
 
     @Override
-    public ProgressCheck newInstance(final JsonObject config) throws Exception {
+    public ProgressCheck newInstance(final JsonObject config) {
         final List<String> rootPaths = JavaxJson.optArray(config, keys().rootPaths()).map(JavaxJson::mapArrayOfStrings)
                 .orElse(DEFAULT_ROOT_PATHS);
         return new Check(rootPaths);

--- a/core/src/main/java/net/adamcin/oakpal/core/sling/DefaultSlingSimulator.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/sling/DefaultSlingSimulator.java
@@ -119,9 +119,9 @@ public final class DefaultSlingSimulator implements SlingSimulatorBackend, Sling
         return installable.getScripts();
     }
 
-    public @Nullable Fun.ThrowingSupplier<JcrPackage>
-    openEmbeddedPackage(@NotNull final EmbeddedPackageInstallable installable) {
-        return () -> packageManager.open(session.getNode(installable.getJcrPath()), true);
+    public @Nullable JcrPackage
+    openEmbeddedPackage(@NotNull final EmbeddedPackageInstallable installable) throws RepositoryException {
+        return packageManager.open(session.getNode(installable.getJcrPath()), true);
     }
 
     @Override


### PR DESCRIPTION
Spotted two minor issues:

* There's no need for the `newInstance` method to throw an `Exception`
* In `DefaultSlingSimulator`, there was a double-wrapping in a `Fun.ThrowingSupplier`, i.e. `open` returned a `Fun.ThrowingSupplier` which in turn returned another `Fun.ThrowingSupplier`.