### PR TITLE
fix test failure in IntelliJ

### DIFF
--- a/core/src/test/java/net/adamcin/oakpal/core/OakMachineTest.java
+++ b/core/src/test/java/net/adamcin/oakpal/core/OakMachineTest.java
@@ -40,6 +40,7 @@ import org.apache.jackrabbit.vault.fs.config.MetaInf;
 import org.apache.jackrabbit.vault.fs.io.Archive;
 import org.apache.jackrabbit.vault.packaging.InstallContext;
 import org.apache.jackrabbit.vault.packaging.InstallHookProcessor;
+import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.JcrPackageManager;
 import org.apache.jackrabbit.vault.packaging.PackageException;
 import org.apache.jackrabbit.vault.packaging.PackageId;
@@ -803,10 +804,11 @@ public class OakMachineTest {
             }
         }).when(installWatcher).dequeueInstallable();
 
+        final JcrPackage jcrPackage = mock(JcrPackage.class);
         final CompletableFuture<EmbeddedPackageInstallable> openedSlot = new CompletableFuture<>();
         doAnswer(call -> {
             openedSlot.complete(call.getArgument(0));
-            return null;
+            return (Fun.ThrowingSupplier<JcrPackage>) () -> jcrPackage;
         }).when(installWatcher).open(installable);
 
         new OakMachine.Builder()


### PR DESCRIPTION
Possibly last one... I noticed that this test fails in IntelliJ, but not Maven with:

```
java.lang.IllegalArgumentException: Argument for @NotNull parameter 'jcrPackageSupplier' of net/adamcin/oakpal/core/OakMachine.internalProcessSubpackage must not be null

	at net.adamcin.oakpal.core.OakMachine.$$$reportNull$$$0(OakMachine.java)
	at net.adamcin.oakpal.core.OakMachine.internalProcessSubpackage(OakMachine.java)
	at net.adamcin.oakpal.core.OakMachine.processEmbeddedPackage(OakMachine.java:922)
	at net.adamcin.oakpal.core.OakMachine.processInstallableQueue(OakMachine.java:971)
	at net.adamcin.oakpal.core.OakMachineTest.testProcessInstallableQueue_singleSubpackageInstallable(OakMachineTest.java:814)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.mockito.internal.runners.DefaultInternalRunner$1$1.evaluate(DefaultInternalRunner.java:46)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.mockito.internal.runners.DefaultInternalRunner$1.run(DefaultInternalRunner.java:77)
	at org.mockito.internal.runners.DefaultInternalRunner.run(DefaultInternalRunner.java:83)
	at org.mockito.internal.runners.StrictRunner.run(StrictRunner.java:39)
	at org.mockito.junit.MockitoJUnitRunner.run(MockitoJUnitRunner.java:163)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)
```