### PR TITLE
add caliper packages and GrandTourIT to core

### DIFF
--- a/calipers/README.md
+++ b/calipers/README.md
@@ -1,0 +1,5 @@
+# OakPAL Caliper
+
+The OakPAL Caliper is a content package that exercises all the features of the OakMachine and events handled by the 
+ProgressCheck interface. It is published as an artifact in its own right so that it can be used as a standalone 
+self-test for a configured instance of the CLI or Maven Plugin. 

--- a/calipers/all/README.md
+++ b/calipers/all/README.md
@@ -1,0 +1,1 @@
+# oakpal-caliper.all

--- a/calipers/all/pom.xml
+++ b/calipers/all/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adamcin.oakpal</groupId>
+        <artifactId>oakpal-calipers</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oakpal-caliper.all</artifactId>
+    <packaging>content-package</packaging>
+
+    <name>OakPAL - Calipers - all package</name>
+    <description>OakPAL Caliper - well-formed all package containing ui.apps and ui.content packages.</description>
+
+    <inceptionYear>2017</inceptionYear>
+
+    <scm>
+        <url>https://github.com/adamcin/oakpal</url>
+        <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
+        <connection>scm:git://github.com/adamcin/oakpal.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <build>
+        <plugins>
+            <!-- ====================================================================== -->
+            <!-- V A U L T   P A C K A G E   P L U G I N S                              -->
+            <!-- ====================================================================== -->
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>net.adamcin.oakpal</group>
+                    <packageType>mixed</packageType>
+                    <embeddeds>
+                        <embedded>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.apps</artifactId>
+                            <type>zip</type>
+                            <target>/apps/oakpal-caliper-packages/application/install</target>
+                        </embedded>
+                        <embedded>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.apps.author</artifactId>
+                            <type>zip</type>
+                            <target>/apps/oakpal-caliper-packages/application/install.author</target>
+                        </embedded>
+                        <embedded>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.apps.publish</artifactId>
+                            <type>zip</type>
+                            <target>/apps/oakpal-caliper-packages/application/install.publish</target>
+                        </embedded>
+                        <embedded>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.content</artifactId>
+                            <type>zip</type>
+                            <target>/apps/oakpal-caliper-packages/content/install</target>
+                        </embedded>
+                    </embeddeds>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.apps</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.apps.author</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.apps.publish</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.content</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/calipers/all/src/main/content/META-INF/vault/filter.xml
+++ b/calipers/all/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<workspaceFilter version="1.0">
+    <filter root="/apps/oakpal-caliper-packages"/>
+</workspaceFilter>

--- a/calipers/all/src/site/site.xml
+++ b/calipers/all/src/site/site.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="${project.name}">
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+        </menu>
+    </body>
+</project>

--- a/calipers/pom.xml
+++ b/calipers/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adamcin.oakpal</groupId>
+        <artifactId>oakpal</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oakpal-calipers</artifactId>
+    <packaging>pom</packaging>
+
+    <name>OakPAL - Calipers - Parent</name>
+    <description>Parent project for OakPAL Caliper Packages</description>
+
+    <inceptionYear>2017</inceptionYear>
+
+    <scm>
+        <url>https://github.com/adamcin/oakpal</url>
+        <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
+        <connection>scm:git://github.com/adamcin/oakpal.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <modules>
+        <module>ui.apps.structure</module>
+        <module>ui.apps</module>
+        <module>ui.apps.author</module>
+        <module>ui.apps.publish</module>
+        <module>ui.content</module>
+        <module>ui.content.suba2</module>
+        <module>ui.content.subb3</module>
+        <module>ui.content.subc1</module>
+        <module>all</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.jackrabbit</groupId>
+                    <artifactId>filevault-package-maven-plugin</artifactId>
+                    <version>1.1.4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/calipers/src/site/site.xml
+++ b/calipers/src/site/site.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="${project.name}">
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+        </menu>
+    </body>
+</project>

--- a/calipers/ui.apps.author/README.md
+++ b/calipers/ui.apps.author/README.md
@@ -1,0 +1,1 @@
+# oakpal-caliper.ui.apps.author

--- a/calipers/ui.apps.author/pom.xml
+++ b/calipers/ui.apps.author/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adamcin.oakpal</groupId>
+        <artifactId>oakpal-calipers</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oakpal-caliper.ui.apps.author</artifactId>
+    <packaging>content-package</packaging>
+
+    <name>OakPAL - Calipers - ui.apps.author</name>
+    <description>OakPAL Caliper - well-formed ui.apps.author package delivering content for author run mode only.</description>
+
+    <inceptionYear>2017</inceptionYear>
+
+    <scm>
+        <url>https://github.com/adamcin/oakpal</url>
+        <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
+        <connection>scm:git://github.com/adamcin/oakpal.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <!-- ====================================================================== -->
+    <!-- B U I L D   D E F I N I T I O N                                        -->
+    <!-- ====================================================================== -->
+    <build>
+        <sourceDirectory>src/main/content/jcr_root</sourceDirectory>
+        <plugins>
+            <!-- ====================================================================== -->
+            <!-- V A U L T   P A C K A G E   P L U G I N S                              -->
+            <!-- ====================================================================== -->
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>net.adamcin.oakpal</group>
+                    <name>oakpal-caliper.ui.apps.author</name>
+                    <packageType>application</packageType>
+                    <accessControlHandling>merge</accessControlHandling>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                    </properties>
+                    <repositoryStructurePackages>
+                        <repositoryStructurePackage>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.apps.structure</artifactId>
+                        </repositoryStructurePackage>
+                    </repositoryStructurePackages>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.apps.structure</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/calipers/ui.apps.author/src/main/content/META-INF/vault/filter.xml
+++ b/calipers/ui.apps.author/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<workspaceFilter version="1.0">
+    <filter root="/apps/oakpal-caliper-author"/>
+</workspaceFilter>

--- a/calipers/ui.apps.author/src/main/content/jcr_root/apps/.content.xml
+++ b/calipers/ui.apps.author/src/main/content/jcr_root/apps/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/calipers/ui.apps.author/src/main/content/jcr_root/apps/oakpal-caliper-author/.content.xml
+++ b/calipers/ui.apps.author/src/main/content/jcr_root/apps/oakpal-caliper-author/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/calipers/ui.apps.author/src/site/site.xml
+++ b/calipers/ui.apps.author/src/site/site.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="${project.name}">
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+        </menu>
+    </body>
+</project>

--- a/calipers/ui.apps.publish/README.md
+++ b/calipers/ui.apps.publish/README.md
@@ -1,0 +1,1 @@
+# oakpal-caliper.ui.apps.publish

--- a/calipers/ui.apps.publish/pom.xml
+++ b/calipers/ui.apps.publish/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adamcin.oakpal</groupId>
+        <artifactId>oakpal-calipers</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oakpal-caliper.ui.apps.publish</artifactId>
+    <packaging>content-package</packaging>
+
+    <name>OakPAL - Calipers - ui.apps.publish</name>
+    <description>OakPAL Caliper - well-formed ui.apps package delivering content for publish run mode only.</description>
+
+    <inceptionYear>2017</inceptionYear>
+
+    <scm>
+        <url>https://github.com/adamcin/oakpal</url>
+        <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
+        <connection>scm:git://github.com/adamcin/oakpal.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <!-- ====================================================================== -->
+    <!-- B U I L D   D E F I N I T I O N                                        -->
+    <!-- ====================================================================== -->
+    <build>
+        <sourceDirectory>src/main/content/jcr_root</sourceDirectory>
+        <plugins>
+            <!-- ====================================================================== -->
+            <!-- V A U L T   P A C K A G E   P L U G I N S                              -->
+            <!-- ====================================================================== -->
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>net.adamcin.oakpal</group>
+                    <name>oakpal-caliper.ui.apps.publish</name>
+                    <packageType>application</packageType>
+                    <accessControlHandling>merge</accessControlHandling>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                    </properties>
+                    <repositoryStructurePackages>
+                        <repositoryStructurePackage>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.apps.structure</artifactId>
+                        </repositoryStructurePackage>
+                    </repositoryStructurePackages>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.apps.structure</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/calipers/ui.apps.publish/src/main/content/META-INF/vault/filter.xml
+++ b/calipers/ui.apps.publish/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<workspaceFilter version="1.0">
+    <filter root="/apps/oakpal-caliper-publish"/>
+</workspaceFilter>

--- a/calipers/ui.apps.publish/src/main/content/jcr_root/apps/.content.xml
+++ b/calipers/ui.apps.publish/src/main/content/jcr_root/apps/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/calipers/ui.apps.publish/src/main/content/jcr_root/apps/oakpal-caliper-publish/.content.xml
+++ b/calipers/ui.apps.publish/src/main/content/jcr_root/apps/oakpal-caliper-publish/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/calipers/ui.apps.publish/src/site/site.xml
+++ b/calipers/ui.apps.publish/src/site/site.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="${project.name}">
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+        </menu>
+    </body>
+</project>

--- a/calipers/ui.apps.structure/README.md
+++ b/calipers/ui.apps.structure/README.md
@@ -1,0 +1,1 @@
+# oakpal-caliper.ui.apps.structure

--- a/calipers/ui.apps.structure/pom.xml
+++ b/calipers/ui.apps.structure/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adamcin.oakpal</groupId>
+        <artifactId>oakpal-calipers</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oakpal-caliper.ui.apps.structure</artifactId>
+    <packaging>content-package</packaging>
+
+    <name>OakPAL - Calipers - ui.apps repository structure</name>
+    <description>OakPAL Caliper - empty repository structure package for ui.apps filter.</description>
+
+    <inceptionYear>2017</inceptionYear>
+
+    <scm>
+        <url>https://github.com/adamcin/oakpal</url>
+        <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
+        <connection>scm:git://github.com/adamcin/oakpal.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <!-- ====================================================================== -->
+    <!-- B U I L D   D E F I N I T I O N                                        -->
+    <!-- ====================================================================== -->
+    <build>
+        <plugins>
+            <!-- ====================================================================== -->
+            <!-- V A U L T   P A C K A G E   P L U G I N S                              -->
+            <!-- ====================================================================== -->
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                    </properties>
+                    <filters>
+
+                        <!-- /apps root -->
+                        <filter><root>/apps</root></filter>
+                    </filters>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/calipers/ui.apps.structure/src/site/site.xml
+++ b/calipers/ui.apps.structure/src/site/site.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="${project.name}">
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+        </menu>
+    </body>
+</project>

--- a/calipers/ui.apps/README.md
+++ b/calipers/ui.apps/README.md
@@ -1,0 +1,1 @@
+# oakpal-caliper.ui.apps

--- a/calipers/ui.apps/pom.xml
+++ b/calipers/ui.apps/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adamcin.oakpal</groupId>
+        <artifactId>oakpal-calipers</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oakpal-caliper.ui.apps</artifactId>
+    <packaging>content-package</packaging>
+
+    <name>OakPAL - Calipers - ui.apps</name>
+    <description>OakPAL Caliper - well-formed ui.apps package containing /apps/ content.</description>
+
+    <inceptionYear>2017</inceptionYear>
+
+    <scm>
+        <url>https://github.com/adamcin/oakpal</url>
+        <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
+        <connection>scm:git://github.com/adamcin/oakpal.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <!-- ====================================================================== -->
+    <!-- B U I L D   D E F I N I T I O N                                        -->
+    <!-- ====================================================================== -->
+    <build>
+        <sourceDirectory>src/main/content/jcr_root</sourceDirectory>
+        <plugins>
+            <!-- ====================================================================== -->
+            <!-- V A U L T   P A C K A G E   P L U G I N S                              -->
+            <!-- ====================================================================== -->
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>net.adamcin.oakpal</group>
+                    <name>oakpal-caliper.ui.apps</name>
+                    <packageType>mixed</packageType>
+                    <accessControlHandling>merge</accessControlHandling>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                    </properties>
+                    <repositoryStructurePackages>
+                        <repositoryStructurePackage>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.apps.structure</artifactId>
+                        </repositoryStructurePackage>
+                    </repositoryStructurePackages>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.apps.structure</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/calipers/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/calipers/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<workspaceFilter version="1.0">
+    <filter root="/apps/oakpal-caliper"/>
+</workspaceFilter>

--- a/calipers/ui.apps/src/main/content/jcr_root/apps/.content.xml
+++ b/calipers/ui.apps/src/main/content/jcr_root/apps/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/calipers/ui.apps/src/main/content/jcr_root/apps/oakpal-caliper/.content.xml
+++ b/calipers/ui.apps/src/main/content/jcr_root/apps/oakpal-caliper/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/calipers/ui.apps/src/main/content/jcr_root/apps/oakpal-caliper/config/org.apache.sling.jcr.repoinit.RepositoryInitializer~init.config
+++ b/calipers/ui.apps/src/main/content/jcr_root/apps/oakpal-caliper/config/org.apache.sling.jcr.repoinit.RepositoryInitializer~init.config
@@ -1,0 +1,3 @@
+scripts=[
+"register nodetypes\n<<===\n<'sling'='http://sling.apache.org/jcr/sling/1.0'>\n[sling:OsgiConfig] > nt:unstructured, nt:hierarchyNode\n===>>\n"
+]

--- a/calipers/ui.apps/src/site/site.xml
+++ b/calipers/ui.apps/src/site/site.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="${project.name}">
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+        </menu>
+    </body>
+</project>

--- a/calipers/ui.content.suba2/README.md
+++ b/calipers/ui.content.suba2/README.md
@@ -1,0 +1,1 @@
+# oakpal-caliper.ui.content.suba2

--- a/calipers/ui.content.suba2/pom.xml
+++ b/calipers/ui.content.suba2/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adamcin.oakpal</groupId>
+        <artifactId>oakpal-calipers</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oakpal-caliper.ui.content.suba2</artifactId>
+    <packaging>content-package</packaging>
+
+    <name>OakPAL - Calipers - ui.content.suba2</name>
+    <description>OakPAL Caliper - well-formed ui.content subpackage alpha-two. listed first, installed second.</description>
+
+    <inceptionYear>2017</inceptionYear>
+
+    <scm>
+        <url>https://github.com/adamcin/oakpal</url>
+        <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
+        <connection>scm:git://github.com/adamcin/oakpal.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <build>
+        <plugins>
+            <!-- ====================================================================== -->
+            <!-- V A U L T   P A C K A G E   P L U G I N S                              -->
+            <!-- ====================================================================== -->
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>net.adamcin.oakpal</group>
+                    <name>oakpal-caliper.ui.content.suba2</name>
+                    <packageType>content</packageType>
+                    <accessControlHandling>merge</accessControlHandling>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.apps</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.apps</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/calipers/ui.content.suba2/src/main/content/META-INF/vault/filter.xml
+++ b/calipers/ui.content.suba2/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<workspaceFilter version="1.0">
+    <filter root="/content/oakpal-caliper"/>
+</workspaceFilter>

--- a/calipers/ui.content.suba2/src/main/content/jcr_root/content/oakpal-caliper/.content.xml
+++ b/calipers/ui.content.suba2/src/main/content/jcr_root/content/oakpal-caliper/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/calipers/ui.content.suba2/src/site/site.xml
+++ b/calipers/ui.content.suba2/src/site/site.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="${project.name}">
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+        </menu>
+    </body>
+</project>

--- a/calipers/ui.content.subb3/README.md
+++ b/calipers/ui.content.subb3/README.md
@@ -1,0 +1,1 @@
+# oakpal-caliper.ui.content.subb3

--- a/calipers/ui.content.subb3/pom.xml
+++ b/calipers/ui.content.subb3/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adamcin.oakpal</groupId>
+        <artifactId>oakpal-calipers</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oakpal-caliper.ui.content.subb3</artifactId>
+    <packaging>content-package</packaging>
+
+    <name>OakPAL - Calipers - ui.content.subb3</name>
+    <description>OakPAL Caliper - well-formed ui.content subpackage bravo-three. listed second, installed third.</description>
+
+    <inceptionYear>2017</inceptionYear>
+
+    <scm>
+        <url>https://github.com/adamcin/oakpal</url>
+        <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
+        <connection>scm:git://github.com/adamcin/oakpal.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <build>
+        <plugins>
+            <!-- ====================================================================== -->
+            <!-- V A U L T   P A C K A G E   P L U G I N S                              -->
+            <!-- ====================================================================== -->
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>net.adamcin.oakpal</group>
+                    <name>oakpal-caliper.ui.content.subb3</name>
+                    <packageType>content</packageType>
+                    <accessControlHandling>merge</accessControlHandling>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.apps</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.apps</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/calipers/ui.content.subb3/src/main/content/META-INF/vault/filter.xml
+++ b/calipers/ui.content.subb3/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<workspaceFilter version="1.0">
+    <filter root="/content/oakpal-caliper"/>
+</workspaceFilter>

--- a/calipers/ui.content.subb3/src/main/content/jcr_root/content/oakpal-caliper/.content.xml
+++ b/calipers/ui.content.subb3/src/main/content/jcr_root/content/oakpal-caliper/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/calipers/ui.content.subb3/src/site/site.xml
+++ b/calipers/ui.content.subb3/src/site/site.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="${project.name}">
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+        </menu>
+    </body>
+</project>

--- a/calipers/ui.content.subc1/README.md
+++ b/calipers/ui.content.subc1/README.md
@@ -1,0 +1,1 @@
+# oakpal-caliper.ui.content.subc1

--- a/calipers/ui.content.subc1/pom.xml
+++ b/calipers/ui.content.subc1/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adamcin.oakpal</groupId>
+        <artifactId>oakpal-calipers</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oakpal-caliper.ui.content.subc1</artifactId>
+    <packaging>content-package</packaging>
+
+    <name>OakPAL - Calipers - ui.content.subc1</name>
+    <description>OakPAL Caliper - well-formed ui.content subpackage charlie-one. listed third, installed first.</description>
+
+    <inceptionYear>2017</inceptionYear>
+
+    <scm>
+        <url>https://github.com/adamcin/oakpal</url>
+        <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
+        <connection>scm:git://github.com/adamcin/oakpal.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <build>
+        <plugins>
+            <!-- ====================================================================== -->
+            <!-- V A U L T   P A C K A G E   P L U G I N S                              -->
+            <!-- ====================================================================== -->
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>net.adamcin.oakpal</group>
+                    <name>oakpal-caliper.ui.content.subc1</name>
+                    <packageType>content</packageType>
+                    <accessControlHandling>merge</accessControlHandling>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.apps</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.apps</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/calipers/ui.content.subc1/src/main/content/META-INF/vault/filter.xml
+++ b/calipers/ui.content.subc1/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<workspaceFilter version="1.0">
+    <filter root="/content/oakpal-caliper"/>
+</workspaceFilter>

--- a/calipers/ui.content.subc1/src/main/content/jcr_root/content/oakpal-caliper/.content.xml
+++ b/calipers/ui.content.subc1/src/main/content/jcr_root/content/oakpal-caliper/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/calipers/ui.content.subc1/src/site/site.xml
+++ b/calipers/ui.content.subc1/src/site/site.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="${project.name}">
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+        </menu>
+    </body>
+</project>

--- a/calipers/ui.content/README.md
+++ b/calipers/ui.content/README.md
@@ -1,0 +1,1 @@
+# oakpal-caliper.ui.content

--- a/calipers/ui.content/pom.xml
+++ b/calipers/ui.content/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.adamcin.oakpal</groupId>
+        <artifactId>oakpal-calipers</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>oakpal-caliper.ui.content</artifactId>
+    <packaging>content-package</packaging>
+
+    <name>OakPAL - Calipers - ui.content</name>
+    <description>OakPAL Caliper - well-formed ui.content package containing non-/apps/ content.</description>
+
+    <inceptionYear>2017</inceptionYear>
+
+    <scm>
+        <url>https://github.com/adamcin/oakpal</url>
+        <developerConnection>scm:git:git@github.com:adamcin/oakpal.git</developerConnection>
+        <connection>scm:git://github.com/adamcin/oakpal.git</connection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <build>
+        <plugins>
+            <!-- ====================================================================== -->
+            <!-- V A U L T   P A C K A G E   P L U G I N S                              -->
+            <!-- ====================================================================== -->
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>net.adamcin.oakpal</group>
+                    <name>oakpal-caliper.ui.content</name>
+                    <packageType>content</packageType>
+                    <accessControlHandling>merge</accessControlHandling>
+                    <properties>
+                        <cloudManagerTarget>none</cloudManagerTarget>
+                        <subPackageHandling>oakpal-caliper.ui.content.subc1,oakpal-caliper.ui.content.suba2;ignore,oakpal-caliper.ui.content.subb3</subPackageHandling>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.apps</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <subPackages>
+                        <subPackage>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.content.suba2</artifactId>
+                            <filter>true</filter>
+                        </subPackage>
+                        <subPackage>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.content.subb3</artifactId>
+                            <filter>true</filter>
+                        </subPackage>
+                        <subPackage>
+                            <groupId>net.adamcin.oakpal</groupId>
+                            <artifactId>oakpal-caliper.ui.content.subc1</artifactId>
+                            <filter>true</filter>
+                        </subPackage>
+                    </subPackages>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.apps</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.content.suba2</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.content.subb3</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.ui.content.subc1</artifactId>
+            <version>2.2.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/calipers/ui.content/src/main/content/META-INF/vault/filter.xml
+++ b/calipers/ui.content/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<workspaceFilter version="1.0">
+    <filter root="/content/oakpal-caliper"/>
+</workspaceFilter>

--- a/calipers/ui.content/src/main/content/jcr_root/content/oakpal-caliper/.content.xml
+++ b/calipers/ui.content/src/main/content/jcr_root/content/oakpal-caliper/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:rep="internal"
+          jcr:mixinTypes="[rep:AccessControllable]"
+          jcr:primaryType="nt:folder"/>

--- a/calipers/ui.content/src/site/site.xml
+++ b/calipers/ui.content/src/site/site.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2018 Mark Adamcin
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project name="${project.name}">
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html" />
+        </menu>
+    </body>
+</project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,6 +59,9 @@
                     <execution>
                         <id>unpack-test-packages</id>
                     </execution>
+                    <execution>
+                        <id>copy-caliper-all</id>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -277,6 +280,12 @@
         <dependency>
             <groupId>net.adamcin.oakpal</groupId>
             <artifactId>oakpal-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.all</artifactId>
+            <type>zip</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/net/adamcin/oakpal/core/checks/SlingJcrInstaller.java
+++ b/core/src/main/java/net/adamcin/oakpal/core/checks/SlingJcrInstaller.java
@@ -96,7 +96,7 @@ public final class SlingJcrInstaller implements ProgressCheckFactory {
         }
 
         Pattern compileInstallPattern(final @NotNull Set<String> runModes) {
-            return Pattern.compile(String.format("^(/[^/]*)*/(install|config)(.(%s))*$",
+            return Pattern.compile(String.format("^(/[^/]*)*/(install|config)(\\.(%s))*$",
                     String.join("|", runModes)));
         }
 

--- a/core/src/test/java/net/adamcin/oakpal/it/GrandTourIT.java
+++ b/core/src/test/java/net/adamcin/oakpal/it/GrandTourIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Mark Adamcin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.adamcin.oakpal.it;
+
+import net.adamcin.oakpal.api.ProgressCheck;
+import net.adamcin.oakpal.api.Violation;
+import net.adamcin.oakpal.core.OakpalPlan;
+import net.adamcin.oakpal.core.checks.SlingJcrInstaller;
+import net.adamcin.oakpal.core.sling.DefaultSlingSimulator;
+import net.adamcin.oakpal.testing.TestPackageUtil;
+import org.apache.jackrabbit.vault.packaging.PackageId;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static net.adamcin.oakpal.api.JavaxJson.obj;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GrandTourIT {
+
+    private File grandTourPackage = TestPackageUtil.getCaliperPackage();
+
+    private List<String> installOrderFull = Arrays.asList(
+            "oakpal-caliper.all",
+            "oakpal-caliper.ui.apps",
+            "oakpal-caliper.ui.apps.author",
+            "oakpal-caliper.ui.apps.publish",
+            "oakpal-caliper.ui.content",
+            "oakpal-caliper.ui.content.subc1",
+            "oakpal-caliper.ui.content.suba2",
+            "oakpal-caliper.ui.content.subb3"
+    );
+
+    private List<String> installOrderNoRunModesNoSubs = Arrays.asList(
+            "oakpal-caliper.all",
+            "oakpal-caliper.ui.apps",
+            "oakpal-caliper.ui.content"
+    );
+
+    @Before
+    public void setUp() throws Exception {
+        assertTrue("expect grand tour package has been copied to " + grandTourPackage.getAbsolutePath(),
+                grandTourPackage.exists());
+    }
+
+    @Test
+    public void testScanNoRunModes() throws Exception {
+        OakpalPlan.fromJson(obj().get()).toOakMachineBuilder(null, getClass().getClassLoader()).build()
+                .scanPackage(grandTourPackage);
+    }
+
+    @Test
+    public void testScanNoRunModes_captureIdentifiedPackages() throws Exception {
+        final List<PackageId> identifiedPackageIds = new ArrayList<>();
+        final ProgressCheck check = new ProgressCheck() {
+            @Override
+            public void identifyPackage(final PackageId packageId, final File file) {
+                identifiedPackageIds.add(packageId);
+            }
+
+            @Override
+            public void identifySubpackage(final PackageId packageId, final PackageId parentId) {
+                identifiedPackageIds.add(packageId);
+            }
+
+            @Override
+            public void identifyEmbeddedPackage(final PackageId packageId, final PackageId parentId, final String jcrPath) {
+                identifiedPackageIds.add(packageId);
+            }
+
+            @Override
+            public Collection<Violation> getReportedViolations() {
+                return Collections.emptyList();
+            }
+        };
+        OakpalPlan.fromJson(obj().get())
+                .toOakMachineBuilder(null, getClass().getClassLoader())
+                .withProgressCheck(check, new SlingJcrInstaller().newInstance(obj().get()))
+                .withSlingSimulator(DefaultSlingSimulator.instance())
+                .withSubpackageSilencer((sub, parent) -> true)
+                .build()
+                .scanPackage(grandTourPackage);
+
+        assertEquals("expect identified packages in order", installOrderNoRunModesNoSubs,
+                identifiedPackageIds.stream().map(PackageId::getName).collect(Collectors.toList()));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <module>webster</module>
         <module>maven</module>
         <module>testing</module>
+        <module>calipers</module>
     </modules>
 
     <properties>
@@ -153,6 +154,26 @@
                                         <includes>
                                             */${vault.test-packages.src}/*
                                         </includes>
+                                    </artifactItem>
+                                </artifactItems>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>copy-caliper-all</id>
+                            <phase>generate-test-resources</phase>
+                            <goals>
+                                <goal>copy</goal>
+                            </goals>
+                            <configuration>
+                                <stripVersion>true</stripVersion>
+                                <artifactItems>
+                                    <artifactItem>
+                                        <groupId>net.adamcin.oakpal</groupId>
+                                        <artifactId>oakpal-caliper.all</artifactId>
+                                        <version>${project.version}</version>
+                                        <type>zip</type>
+                                        <overWrite>true</overWrite>
+                                        <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                                     </artifactItem>
                                 </artifactItems>
                             </configuration>
@@ -499,6 +520,12 @@
                 <groupId>net.adamcin.oakpal</groupId>
                 <artifactId>oakpal-testing</artifactId>
                 <version>2.2.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>net.adamcin.oakpal</groupId>
+                <artifactId>oakpal-caliper.all</artifactId>
+                <version>2.2.0-SNAPSHOT</version>
+                <type>zip</type>
             </dependency>
             <dependency>
                 <groupId>net.adamcin.oakpal</groupId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -59,6 +59,9 @@
                     <execution>
                         <id>unpack-test-packages</id>
                     </execution>
+                    <execution>
+                        <id>copy-caliper-all</id>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -80,6 +83,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.adamcin.oakpal</groupId>
+            <artifactId>oakpal-caliper.all</artifactId>
+            <type>zip</type>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/testing/src/main/java/net/adamcin/oakpal/testing/TestPackageUtil.java
+++ b/testing/src/main/java/net/adamcin/oakpal/testing/TestPackageUtil.java
@@ -88,6 +88,10 @@ public final class TestPackageUtil {
         return file;
     }
 
+    public static File getCaliperPackage() {
+        return Paths.get("target/test-classes/oakpal-caliper.all.zip").toFile();
+    }
+
     public static File prepareTestPackageFromFolder(final @NotNull String filename,
                                                     final @NotNull File srcFolder) throws IOException {
         final File absFile = srcFolder.getAbsoluteFile();

--- a/testing/src/test/java/net/adamcin/oakpal/testing/TestPackageUtilTest.java
+++ b/testing/src/test/java/net/adamcin/oakpal/testing/TestPackageUtilTest.java
@@ -171,4 +171,10 @@ public class TestPackageUtilTest {
         TestPackageUtil.buildJarFromDir(new File("src/test/resources/extracted/simple"),
                 outJar, Collections.emptyMap());
     }
+
+    @Test
+    public void testGetCaliperPackage() {
+        File file = TestPackageUtil.getCaliperPackage();
+        assertTrue("expect file exists", file.exists());
+    }
 }


### PR DESCRIPTION
I happen to know that subPackageHandling is not fully respected by OakMachine in terms of defining installation order of subpackages, and I wanted to have this kind of happy path test package available before I implemented the sorting. The other justifications for including this content package graph as first-order maven modules instead of just prebuilding a zip or nesting directories of flat files like other test packages include:
* better tracking of the evolution of the `filevault-package-maven-plugin` and the resulting artifacts
* more obvious relationship at a glance between AEM maven project conventions and progress check logic
* publishing a valid, complex content package artifact to maven central will make it available for use as a test artifact in other contexts downstream